### PR TITLE
Feat: 매너 점수 기능

### DIFF
--- a/src/main/java/com/gdsc/projectmiobackend/common/Manner.java
+++ b/src/main/java/com/gdsc/projectmiobackend/common/Manner.java
@@ -1,0 +1,14 @@
+package com.gdsc.projectmiobackend.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Manner {
+    GOOD("좋음"),
+    NORMAL("보통"),
+    BAD("나쁨");
+
+    private final String manner;
+}

--- a/src/main/java/com/gdsc/projectmiobackend/controller/PostController.java
+++ b/src/main/java/com/gdsc/projectmiobackend/controller/PostController.java
@@ -2,6 +2,7 @@ package com.gdsc.projectmiobackend.controller;
 
 
 import com.gdsc.projectmiobackend.dto.PostDto;
+import com.gdsc.projectmiobackend.dto.request.MannerUpdateRequestDto;
 import com.gdsc.projectmiobackend.dto.request.PostCreateRequestDto;
 import com.gdsc.projectmiobackend.dto.request.PostPatchRequestDto;
 import com.gdsc.projectmiobackend.dto.request.PostVerifyFinishRequestDto;
@@ -163,5 +164,35 @@ public class PostController {
     public ResponseEntity<String> getApprovalUserCountByPost(@PathVariable Long postId) {
         String result = postService.getApprovalUserCountByPost(postId);
         return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "기사 매너 평가")
+    @PostMapping("/post/{postId}/evaluation/driver")
+    public ResponseEntity<?> updateDriverMannerScore(@PathVariable Long postId,
+                                                     @AuthenticationPrincipal UserInfo user,
+                                                     @RequestBody MannerUpdateRequestDto mannerUpdateRequestDto) {
+        postService.driverUpdateManner(postId, user.getEmail(), mannerUpdateRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "탑승자 매너 평가")
+    @PostMapping("/post/{userId}/evaluation/passenger")
+    public ResponseEntity<?> updatePassengersMannerScore(@PathVariable Long userId,
+                                                         @AuthenticationPrincipal UserInfo user,
+                                                         @RequestBody MannerUpdateRequestDto mannerUpdateRequestDto) {
+        postService.updateParticipatesManner(userId, mannerUpdateRequestDto, user.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "탑승자로 참여한 게시글")
+    @Parameters({
+            @Parameter(name = "sort", description = "sort specification",
+                    in = ParameterIn.QUERY, schema = @Schema(type = "createDate,desc"))
+    })
+    @GetMapping("/post/participate")
+    public ResponseEntity<Page<PostDto>> readPostByParticipate(@AuthenticationPrincipal UserInfo user,
+                                                               @Parameter(hidden = true) Pageable pageable) {
+        Page<PostDto> postList = this.postService.findByParticipate(user.getEmail(), pageable);
+        return ResponseEntity.ok(postList);
     }
 }

--- a/src/main/java/com/gdsc/projectmiobackend/dto/UserDto.java
+++ b/src/main/java/com/gdsc/projectmiobackend/dto/UserDto.java
@@ -21,7 +21,8 @@ public class UserDto {
     private Boolean verifySmoker;
     private RoleType roleType;
     private Status status;
-
+    private Long mannerCount;
+    private String grade;
     public UserDto(UserEntity user) {
         this.id = user.getId();
         this.email = user.getEmail();
@@ -33,5 +34,7 @@ public class UserDto {
         this.verifySmoker = user.getVerifySmoker();
         this.roleType = user.getRoleType();
         this.status = user.getStatus();
+        this.mannerCount = user.getMannerCount();
+        this.grade = user.getGrade();
     }
 }

--- a/src/main/java/com/gdsc/projectmiobackend/dto/request/MannerUpdateRequestDto.java
+++ b/src/main/java/com/gdsc/projectmiobackend/dto/request/MannerUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.gdsc.projectmiobackend.dto.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MannerUpdateRequestDto {
+    private String manner;
+}

--- a/src/main/java/com/gdsc/projectmiobackend/entity/Participants.java
+++ b/src/main/java/com/gdsc/projectmiobackend/entity/Participants.java
@@ -26,6 +26,9 @@ public class Participants {
     @Nullable
     private Boolean approval;
 
+    @Nullable
+    private Boolean verifyFinish;
+
     public Participants(Post post, UserEntity user) {
         this.post = post;
         this.user = user;

--- a/src/main/java/com/gdsc/projectmiobackend/entity/UserEntity.java
+++ b/src/main/java/com/gdsc/projectmiobackend/entity/UserEntity.java
@@ -47,6 +47,10 @@ public class UserEntity{
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    private Long mannerCount;
+
+    private String grade;
+
     public UserEntity(GoogleOAuth2UserInfo userInfo) {
         this.email = userInfo.getEmail();
         this.studentId = userInfo.getEmail().split("@")[0];

--- a/src/main/java/com/gdsc/projectmiobackend/repository/PostRepository.java
+++ b/src/main/java/com/gdsc/projectmiobackend/repository/PostRepository.java
@@ -17,4 +17,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByUser(UserEntity user, Pageable pageable);
 
     List<Post> findByLatitudeAndLongitude(Double latitude, Double longitude);
+
 }

--- a/src/main/java/com/gdsc/projectmiobackend/service/PostParticipationServiceImpl.java
+++ b/src/main/java/com/gdsc/projectmiobackend/service/PostParticipationServiceImpl.java
@@ -31,13 +31,14 @@ public class PostParticipationServiceImpl implements PostParticipationService {
         List<Participants> participants1 = participantsRepository.findByUserId(user.getId());
 
         for (Participants p : participants1) {
-            if(p.getApproval()==true){
+            if(p.getApproval()){
                 return "다른 카풀에 이미 승인되었습니다.";
             }
         }
 
         Participants participants = new Participants(post, user);
         participants.setApproval(false);
+        participants.setVerifyFinish(false);
         participantsRepository.save(participants);
 
         return "카풀 예약이 완료되었습니다.";
@@ -104,7 +105,8 @@ public class PostParticipationServiceImpl implements PostParticipationService {
 
         for (Participants p : participants1) {
             if (!p.getId().equals(participateId)) {
-                participantsRepository.delete(p);
+                if(!p.getVerifyFinish())
+                    participantsRepository.delete(p);
             }
         }
 

--- a/src/main/java/com/gdsc/projectmiobackend/service/PostService.java
+++ b/src/main/java/com/gdsc/projectmiobackend/service/PostService.java
@@ -2,6 +2,7 @@ package com.gdsc.projectmiobackend.service;
 
 
 import com.gdsc.projectmiobackend.dto.PostDto;
+import com.gdsc.projectmiobackend.dto.request.MannerUpdateRequestDto;
 import com.gdsc.projectmiobackend.dto.request.PostCreateRequestDto;
 import com.gdsc.projectmiobackend.dto.request.PostPatchRequestDto;
 import com.gdsc.projectmiobackend.dto.request.PostVerifyFinishRequestDto;
@@ -35,4 +36,10 @@ public interface PostService {
     List<PostDto> findByLatitudeAndLongitude(Double latitude, Double longitude);
 
     String getApprovalUserCountByPost(Long postId);
+
+    void driverUpdateManner(Long id, String email, MannerUpdateRequestDto mannerUpdateRequestDto);
+
+    void updateParticipatesManner(Long userId, MannerUpdateRequestDto mannerUpdateRequestDto, String email);
+
+    Page<PostDto> findByParticipate(String email, Pageable pageable);
 }


### PR DESCRIPTION
-[x] : 평가 등급(good, normal, bad) 생성
-[x] : 게시글 완료 후 상대 평가 가능(+1, 0, 1) => 탑승자와 운전자는 평가 API가 다름
-[x] : 매너 총 점수로 등급 갱신(F, E, D, C, B...)
-[x] : 기존의 승인되지 않은 참여자들 게시글 완료와 동시에 필터링
-[x] : 탑승자로 참여한 게시글과 운전자로 참여한 게시글의 분리 필요성에 따른 조회 API 추가 생성
-[x] : 게시글 참여 entity에 완료 판별 컬럼을 추가하여 게시글이 완료되면 승인은 false, 완료 판별은 true로 설정되어 불필요한 삭제 가능성을 줄임